### PR TITLE
Fix YAML parsing error.

### DIFF
--- a/docpad.coffee
+++ b/docpad.coffee
@@ -64,7 +64,12 @@ docpadConfig = {
 	collections:
 	# Reveal.js slides
 		slides: (database) ->
-			database.findAllLive({tags: $has: 'slide', slideOrder: $exists: true},{slideOrder:1})
+      query =
+        tags: $has: 'slide'
+        slideOrder: $exists: true
+      sorting =
+        slideOrder: 1
+      database.findAllLive(query, sorting)
 
 }
 

--- a/src/documents/index.html.coffee
+++ b/src/documents/index.html.coffee
@@ -25,4 +25,4 @@ div class:'reveal', ->
 		a class:"down", href:"#", '▼'
 
 	# Presentation progress bar
-	div class:"progress", -> span
+	div class:"progress", -> span ""

--- a/src/layouts/default.html.coffee
+++ b/src/layouts/default.html.coffee
@@ -1,4 +1,3 @@
-# -----------------------------
 # Prepare
 
 # Get our formatted site title as defined by out docpad.cson file


### PR DESCRIPTION
DocPad 6.68 chokes on default.html.coffee when it has a comment that
almost looks like YAML front-matter ('# ---------').
